### PR TITLE
Update maxdb_backup.py - ignore restore jobs and lost history

### DIFF
--- a/SAP-MaxDB/lib/python3/cmk/base/plugins/agent_based/maxdb_backup.py
+++ b/SAP-MaxDB/lib/python3/cmk/base/plugins/agent_based/maxdb_backup.py
@@ -20,6 +20,8 @@ def parse_maxdb_backup(string_table: StringTable) -> MaxDBBackupSection:
             parsed.setdefault(srv, {})
         elif len(line) == 7:
             job, job_type, start, stop, result, error_msg, out = line
+            if job_type.strip() in ['HISTLOST', 'RESTORE']:
+                continue  # ignore lost history and restore jobs            
             if start == stop:
                 duration = 0
                 begin = datetime.strptime(start, "%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Backup logs will also report restore jobs (which might have failed). These should be ignored by this check. Also, after a restore, history of some backup jobs might be lost (status "HISTLOST") and will have an empty job id, which previously caused a crash of the check during parsing.